### PR TITLE
Show hopefully friendlier messages

### DIFF
--- a/flake8_import_style/__init__.py
+++ b/flake8_import_style/__init__.py
@@ -22,21 +22,22 @@ class I8(object):
             if isinstance(i, ast.ImportFrom):
                 if i.module == "__future__":
                     continue
+                module = ("." * i.level) + (i.module or "")
                 names = ", ".join(i.name for i in i.names)
                 if i.module is None:
                     # Relative imports don't work with the `import <>` syntax.
                     message = I801.format(
                         stmt=names,
-                        module="." * i.level,
+                        module=module,
                         names=names)
                 elif len(i.names) == 1:
                     message = I801.format(
                         stmt="{0}.{1}".format(i.module, names),
-                        module=i.module,
+                        module=module,
                         names=names)
                 else:
                     message = I801.format(
                         stmt=i.module,
-                        module=i.module,
+                        module=module,
                         names=names)
                 yield (i.lineno, i.col_offset, message, "I801")

--- a/flake8_import_style/tests/__init__.py
+++ b/flake8_import_style/tests/__init__.py
@@ -34,6 +34,24 @@ class I8Test(unittest.TestCase):
             "I801",
         )])
 
+        tree = ast.parse("from ..mod import obj")
+        i8 = flake8_import_style.I8(tree)
+        self.assertEqual(list(i8.run()), [(
+            1,
+            0,
+            "I801 use 'import mod.obj' instead of 'from ..mod import obj'",
+            "I801",
+        )])
+
+        tree = ast.parse("from .mod import obj1, obj2")
+        i8 = flake8_import_style.I8(tree)
+        self.assertEqual(list(i8.run()), [(
+            1,
+            0,
+            "I801 use 'import mod' instead of 'from .mod import obj1, obj2'",
+            "I801",
+        )])
+
         tree = ast.parse("from mod import obj")
         i8 = flake8_import_style.I8(tree)
         self.assertEqual(list(i8.run()), [(

--- a/flake8_import_style/tests/__init__.py
+++ b/flake8_import_style/tests/__init__.py
@@ -21,7 +21,7 @@ class I8Test(unittest.TestCase):
         self.assertEqual(list(i8.run()), [(
             1,
             0,
-            "I801 use 'import ...' instead of 'from ... import obj'",
+            "I801 use 'import obj' instead of 'from . import obj'",
             "I801",
         )])
 
@@ -30,7 +30,7 @@ class I8Test(unittest.TestCase):
         self.assertEqual(list(i8.run()), [(
             1,
             0,
-            "I801 use 'import ...' instead of 'from ... import obj'",
+            "I801 use 'import obj' instead of 'from .. import obj'",
             "I801",
         )])
 
@@ -39,7 +39,16 @@ class I8Test(unittest.TestCase):
         self.assertEqual(list(i8.run()), [(
             1,
             0,
-            "I801 use 'import mod' instead of 'from mod import obj'",
+            "I801 use 'import mod.obj' instead of 'from mod import obj'",
+            "I801",
+        )])
+
+        tree = ast.parse("from mod import obj1, obj2")
+        i8 = flake8_import_style.I8(tree)
+        self.assertEqual(list(i8.run()), [(
+            1,
+            0,
+            "I801 use 'import mod' instead of 'from mod import obj1, obj2'",
             "I801",
         )])
 


### PR DESCRIPTION
Since relative imports don't work with the `import <>` syntax, suggest importing the names directly. In these cases, the `i.module` is `None` and the `i.level` has the number of levels down in the relative import, e.g. `1` means the current directory.

If there's only one name, suggest:

    use 'import module.name' instead of 'from module import name'

This implements the enhancement proposed in #1.
